### PR TITLE
add parentheses in ambiguous product - addition and product - substraction operations

### DIFF
--- a/latexexpr_efficalc/__init__.py
+++ b/latexexpr_efficalc/__init__.py
@@ -631,7 +631,13 @@ class Operation(object):
         a = self.args
         t = self.type
         if t in _supportedOperationsN:
-            v = (getattr(arg, what)() for arg in a)
+            v = []
+            for arg in a:
+                _s = getattr(arg, what)()
+                if self.type == _MUL:
+                    if isinstance(arg, Operation) and arg.type in [_ADD, _SUB]:
+                        _s = fr"\left({_s}\right)"
+                v.append(_s)
             if t == _ADD:
                 return r" + ".join(v)
             if t == _MUL:

--- a/tests/test_operation_math.py
+++ b/tests/test_operation_math.py
@@ -266,3 +266,19 @@ def test_operation_a_brackets():
         c.str_substituted()
         == " 3 \\ \\mathrm{in} \\cdot  1 \\ \\mathrm{} \\cdot \\left\\langle  2 \\ \\mathrm{} \\cdot  1 \\ \\mathrm{} +  3 \\ \\mathrm{in} \\cdot  1 \\ \\mathrm{} \\right\\rangle"
     )
+
+
+def test_operation_parens_add_sub():
+    a = Variable("a", 2, "foo")
+    b = Variable("b", 3, "bar")
+    c = Variable("c", 5, "baz")
+
+    d = 1 / ((a + b) * c)
+
+    assert d.str_symbolic() == r"\frac{ {1} }{ \left({a} + {b}\right) \cdot {c} }"
+
+    assert d.str_substituted() == (
+        r"\frac"
+        r"{  1 \ \mathrm{} }"
+        r"{ \left( 2 \ \mathrm{foo} +  3 \ \mathrm{bar}\right) \cdot  5 \ \mathrm{baz} }"
+    )


### PR DESCRIPTION
when rendering an expression like (a+b)*c, the previous version of this library produced LaTeX code like `a + b \cdot c`, which doesn't respect the convention for when to add parentheses to indicate priority of an expression.

The change in this PR adjusts the library to generate latex code like `\left( a + b \right) \cdot c`, to reflect the correct operation priority. 

I also added a test for the new code.

Thanks for your time reviewing this.